### PR TITLE
Added functionallity to enable virtual_alias_maps entry in main.cf of…

### DIFF
--- a/examples/services/autorun/postfix.cf
+++ b/examples/services/autorun/postfix.cf
@@ -1,7 +1,7 @@
 bundle common postfix() {
     vars:
         debian::
-            "packages_add"      slist => { "postfix", "bsd-mailx" };
+            "packages_add"      slist => { "postfix", "bsd-mailx", "postfix-ldap" };
             "packages_remove"   slist => { "heirloom-mailx" };
             "service_name"      string => "postfix";
 
@@ -48,9 +48,13 @@ bundle agent postfix_autorun()
 
     methods:
         any::
-            "postfix_install"               usebundle => postfix_install();
-            "postfix_surfsara_config"       usebundle => postfix_surfsara_config();
-            "postfix_daemons_check"         usebundle => postfix_daemons_check();
+            ""  usebundle => sara_data_autorun("postfix");
+            ""  usebundle => postfix_install();
+            ""  usebundle => postfix_surfsara_config();
+            ""  usebundle => postfix_daemons_check();
+
+        POSTFIX_VIRTUAL_MAPS::        
+            "" usebundle => postfix_virtual_alias_maps();
 
 }
 
@@ -102,6 +106,9 @@ bundle agent postfix_surfsara_config
             "sara_etc_postfix_recipient_canonical",
         };
 
+    methods:
+        "" usebundle => sara_mustache_autorun("postfix");
+
     commands:
         POSTFIX_NEWALIAS::
             "$(postfix.newaliases)";
@@ -112,11 +119,27 @@ bundle agent postfix_surfsara_config
         sara_etc_postfix_transport::
             "$(postfix.postmap_cmd) $(postfix.config_dir)/transport"
                 comment => "This is a hashed file, so we need to use postmap after a change";
+}
+
+bundle agent postfix_virtual_alias_maps()
+{
+    vars:
+        "templates" slist => getindices("sara_data.postfix[virtual_alias_maps]");
 
     methods:
-        "" usebundle => sara_template_autorun("postfix");
+        "" usebundle => sara_mustache_copy("postfix", "@(postfix_virtual_alias_maps.templates)");
+        
+    files:
+        "$(sara_data.postfix[virtual_alias_maps][$(templates)][dest])"
+            create => "true",
+            edit_template => "$(def.node_template_dir)/postfix/$(templates)",
+            template_method => "mustache",
+            template_data => "@(sara_data.postfix[virtual_alias_maps][$(templates)][data])",
+            classes => results("namespace", "POSTFIX_$(sara_data.postfix[virtual_alias_maps][$(templates)][dest])");
 
     reports:
+        "$(this.bundle) Template $(templates) : $(sara_data.postfix[virtual_alias_maps][$(templates)][dest])"
+             ifvarclass => "DEBUG|DEBUG_postfix|DEBUG_$(this.bundle)";
 }
 
 @if minimum_version(99.9)
@@ -133,7 +156,11 @@ files will be generated from mustache templates:
  * /etc/postfix/header_checks
  * /etc/postfix/transport
 
-If one of the files is changed then the followong ''class'' will be set:
+Created by the bundle postfix_virtual_alias_map()
+
+ * /etc/postfix/virtual_alias_maps.cf
+
+If one of the files is changed then the following ''class'' will be set:
  * _etc_aliases
  * _etc_postfix_main_cf
  * _etc_postfix_master_cf
@@ -225,6 +252,13 @@ The variables that are set in default.json and can be overwritten. SURFSARA use 
         "hash:/etc/postfix/transport"
     ],
     "unknown_local_recipient_reject_code": 550,
+    "virtual_alias_maps": [
+        {
+            "protocol" : "",
+            "delimiter" : "",
+            "dest" : ""
+        }
+    ],
     "virtual_mailbox_limit": 0
 }
 }}}
@@ -261,5 +295,57 @@ vars:
     "postfix" data => parsejson( '{ "alias_root_email_address":  "file_aliases_lines"  }' );
 }}} 
 
-@endif
+ * to use `virtual_alias_map`s override following and define your own mustache file 
+{{{
+#!json
+    "virtual_alias_maps": [
+        {
+            "protocol" : "",
+            "delimiter" : "",
+            "dest" : ""
+        }
+    ],
+}}}
 
+ * enable VIRTUAL_MAPS class and describe your json file, for example:
+  * VIRTUAL_MAPS will enable virtual_alias_maps in main.cf of postfix
+{{{
+{{#classes.POSTFIX_VIRTUAL_MAPS}}
+{{#vars.sara_data.postfix.virtual_alias_maps}}virtual_alias_maps = {{{protocol}}}{{{delimiter}}}{{{dest}}}, {{/vars.sara_data.postfix.virtual_alias_map}}
+{{/classes.POSTFIX_VIRTUAL_MAPS}}
+}}}
+
+ * Json data file. Postfix bundle will copy the `ldap_aliases_map.mustache` template file and expand it with teh defined data.
+{{{
+#!json
+    "classes" : {
+        "VIRTUAL_MAPS": [ "mta.example.com" ],:
+    },
+    "virtual_alias_maps": {
+        "ldap_aliases_map.mustache" : {
+            "delimiter": ":",
+            "dest": "/etc/postfix/virtual_alias_maps.cf",
+            "protocol": "ldap",
+            "data": {
+                "bind" : true,
+                "bind_options" : {
+                    "dn" : "<your_dn>",
+                    "pw" : "<your_bind_password>"
+                },
+                "port": "636",
+                "query_filter" : "(uid=%s)",
+                "result_attribute" : "mail",
+                "search_base" : "ou=Users,dc=example,dc=com",
+                "server": "ldaps://ldap.example.com"
+            }
+        }
+    }
+}}}
+
+{{{
+#!cf3
+vars:
+    "postfix" data => parsejson( '{ "alias_root_email_address":  "file_aliases_lines"  }' );
+}}} 
+
+@endif

--- a/examples/templates/postfix/dynamicmaps.cf.mustache
+++ b/examples/templates/postfix/dynamicmaps.cf.mustache
@@ -7,3 +7,4 @@
 #====	================================	=============	============
 tcp	    /usr/lib/postfix/dict_tcp.so		dict_tcp_open	
 sqlite	/usr/lib/postfix/dict_sqlite.so		dict_sqlite_open	
+ldap    /usr/lib/postfix/postfix-ldap.so    dict_ldap_open

--- a/examples/templates/postfix/json/default.json
+++ b/examples/templates/postfix/json/default.json
@@ -6,6 +6,13 @@
     "alias_maps": [
         "hash:/etc/aliases"
     ],
+    "virtual_alias_maps": [
+        {
+            "protocol" : "",
+            "delimiter" : "",
+            "dest" : ""
+        }
+    ],
     "append_dot_mydomain": "no",
     "biff": "no",
     "debugger_command": "",
@@ -41,7 +48,7 @@
     "relay_domains": [
         "$mydestination"
     ],
-    "relayhost": "[mta.surfsara.nl]",
+    "relayhost": "[mta.yourdomain.nl]",
     "smtpd_banner": "SURFsara ESMTP host",
     "smtpd_port": "smtp",
     "transport_maps": [

--- a/examples/templates/postfix/json/lisa.json
+++ b/examples/templates/postfix/json/lisa.json
@@ -1,0 +1,24 @@
+{
+    "classes" : {
+        "VIRTUAL_MAPS" : "<hosts_to_enable_class>"
+    },
+    "virtual_alias_maps": {
+        "ldap_aliases_map.mustache" : {
+            "delimiter": ":",
+            "dest": "/etc/postfix/virtual_alias_maps.cf",
+            "protocol": "ldap",
+            "data": {
+                "bind" : true,
+                "bind_options" : { 
+                    "dn" : "cn=name,dc=you,dc=me,dc=her",
+                    "pw" : "<your_password>"
+                }, 
+                "port": "636",
+                "query_filter" : "(uid=%s)",
+                "result_attribute" : "mail",
+                "search_base" : "ou=Users,dc=you,dc=me,dc=her",
+                "server": "ldaps://yourserver.nl"
+            }
+        }
+    }
+}

--- a/examples/templates/postfix/ldap_aliases_map.mustache
+++ b/examples/templates/postfix/ldap_aliases_map.mustache
@@ -1,0 +1,17 @@
+###
+#
+# This file is maintained by CFEngine
+#
+server_host = {{{ server }}}
+server_port = {{{ port }}}
+search_base = {{{ search_base }}}
+{{#bind}}
+bind = yes
+bind_dn = {{{bind_options.dn}}}
+bind_pw = {{{bind_options.pw}}}
+{{/bind}} 
+# look for entries with this
+query_filter = {{{ query_filter }}}
+
+# what attribute from the search result is returned
+result_attribute = {{{ result_attribute }}}

--- a/examples/templates/postfix/main.cf.mustache
+++ b/examples/templates/postfix/main.cf.mustache
@@ -7,6 +7,10 @@ alias_database = {{#vars.sara_data.postfix.alias_database}}{{{.}}},{{/vars.sara_
 
 alias_maps = {{#vars.sara_data.postfix.alias_maps}}{{{.}}},{{/vars.sara_data.postfix.alias_maps}}
 
+{{#classes.POSTFIX_VIRTUAL_MAPS}}
+{{#vars.sara_data.postfix.virtual_alias_maps}}virtual_alias_maps = {{{protocol}}}{{{delimiter}}}{{{dest}}}, {{/vars.sara_data.postfix.virtual_alias_map}}
+{{/classes.POSTFIX_VIRTUAL_MAPS}}
+
 append_dot_mydomain = {{{vars.sara_data.postfix.append_dot_mydomain}}}
 biff = {{{vars.sara_data.postfix.biff}}}
 debugger_command = {{{vars.sara_data.postfix.debugger_command}}}
@@ -22,6 +26,7 @@ mailman_destination_recipient_limit = 1
 {{/vars.sara_data.postfix.mailman_destination_recipient_limit}}
 
 virtual_mailbox_limit = {{{vars.sara_data.postfix.virtual_mailbox_limit}}}
+
 message_size_limit = {{{vars.sara_data.postfix.message_size_limit}}}
 
 mydestination = {{#vars.sara_data.postfix.mydestination}}{{{.}}},{{/vars.sara_data.postfix.mydestination}}


### PR DESCRIPTION
… postfix. virtual_alias_maps.cf will be created from ldap_aliases_map.mustache. defaults are set in default.json. specifics can be set in seperate json file. For example see lisa.json.