### PR TITLE
Added support for SUSE and fixed an issue with postmap

### DIFF
--- a/services/postfix.cf
+++ b/services/postfix.cf
@@ -28,8 +28,20 @@ bundle common postfix() {
             "service_name"      string => "postfix";
             "daemon_name"       string => "/usr/libexec/postfix/master";
 
+        SLES::
+            "packages_add"  data  => parsejson('
+                    {
+                        "mailx" : "",
+                        "postfix" : ""
+                    }
+                ');
+            "service_name"      string => "postfix";
+            "daemon_name"       string => "/usr/lib/postfix/master";
+
         any::
             "newaliases"        string => "/usr/bin/newaliases";
+            "postmap_cmd"       string => "/usr/sbin/postmap";
+            "config_dir"        string => "/etc/postfix/";
         
             ## Mustache templates
             "template_2_destination" data => parsejson('


### PR DESCRIPTION
Added support for Suse Linux Enterprise Server (SLES).

Also added two variables that are needed to re-generated the transport map. It looks like they where never added.