### PR TITLE
sara_services copy files/dir improvements

### DIFF
--- a/masterfiles/lib/surfsara/files.cf
+++ b/masterfiles/lib/surfsara/files.cf
@@ -19,7 +19,7 @@ bundle agent sara_cp_dir_default
        any::
             "attributes" data => parsejson('{
                 "compare": "digest",
-                "preserve": "true",
+                "preserve": "false",
                 "purge": "false",
                 "sync": "false",
                 "type_check": "false"
@@ -106,6 +106,9 @@ classes:
         "$(bundle_name)_copy_dirs_$(index)_run_bundle" expression => isvariable("sara_data.$(bundle_name)[copy_dirs][$(index)][run_bundle]"),
             comment => "Must we run a bundle when a directory is changed";
 
+        "$(bundle_name)_copy_dirs_$(index)_mog_class" expression => isvariable("sara_data.$(bundle_name)[copy_dirs][$(index)][mog]"),
+            comment => "Must we set directory permission and doit recurse";
+
 files:
     any::
         ## Can not use $(this.bundle) in copy_from body, bug?
@@ -115,6 +118,17 @@ files:
             depth_search => recurse_ignore("inf", "$(sara_data.$(bundle_name)[copy_dirs][$(index)][exclude_dirs])" ),
             classes => results("namespace", "$(bundle_name)_copy_dirs_$(index)"),
             ifvarclass => "!$(bundle_name)_copy_dirs_$(index)_kept";
+
+        "$(sara_data.$(bundle_name)[copy_dirs][$(index)][dest])"
+            comment => "Set permission on all files/dirs if requested",
+            perms => mog(
+                "$(sara_data.$(bundle_name)[copy_dirs][$(index)][mog][0])",
+                "$(sara_data.$(bundle_name)[copy_dirs][$(index)][mog][1])",
+                "$(sara_data.$(bundle_name)[copy_dirs][$(index)][mog][2])"
+            ),
+            depth_search => recurse_ignore("inf", "$(sara_data.$(bundle_name)[copy_dirs][$(index)][exclude_dirs])" ),
+            ifvarclass => "$(bundle_name)_copy_dirs_$(index)_mog_class";
+
 
 methods:
     any::
@@ -157,14 +171,16 @@ files:
     any::
         "$(sara_data.$(bundle_name)[copy_files][$(index)][dest])"
             comment => "Copy bundle files and set class if its get copied",
-            copy_from => secure_cp("$(sara_data.$(bundle_name)[copy_files][$(index)][src])", "$(sys.policy_hub)"),
+            copy_from => secure_cp("$(sara_data.$(bundle_name)[copy_files][$(index)][source])", "$(sys.policy_hub)"),
             classes => results("namespace", "$(bundle_name)_copy_files_$(index)");
 
         "$(sara_data.$(bundle_name)[copy_files][$(index)][dest])"
             comment => "Check permission",
-            perms => mog( "$(sara_data.$(bundle_name)[copy_files][$(index)][mode])",
-                "$(sara_data.$(bundle_name)[copy_files][$(index)][owner])",
-                "$(sara_data.$(bundle_name)[copy_files][$(index)][group])");
+            perms => mog(
+                "$(sara_data.$(bundle_name)[copy_files][$(index)][mog][0])",
+                "$(sara_data.$(bundle_name)[copy_files][$(index)][mog][1])",
+                "$(sara_data.$(bundle_name)[copy_files][$(index)][mog][2])"
+            );
 
 methods:
     any::

--- a/services/munge.cf
+++ b/services/munge.cf
@@ -145,10 +145,8 @@ With this variable set it will copy the specified file (usually the munge key) t
 "": [
 {
     "dest": "Destination path with filename",
-    "src": "The filename path on the policy server/cf-hub",
-    "mode":  "The mode bits",
-    "owner": "File owner",
-    "group": "File group",
+    "source": "The filename path on the policy server/cf-hub",
+    "mog": [ "mode", "owner", "group" ],
     "run_bundle": "This bundle will run if the file gets copied"
 }
 ]
@@ -161,8 +159,8 @@ example:
 "copy_files": [
     {
         "dest": "$(munge.munge_key_file)",
-        "src": "cf_bundles_dir/munge/lisa/munge.key",
-        "mode": "0400", "owner": "munge", "group": "munge",
+        "source": "cf_bundles_dir/munge/lisa/munge.key",
+        "mog": [ "0400", "munge", "munge" ],
         "run_bundle": "munge_daemons_restart"
     }
 }

--- a/services/ssh.cf
+++ b/services/ssh.cf
@@ -169,7 +169,7 @@ bundle agent ssh_surfsara_config()
 }
 @if minimum_version(99.9)
 
-= SSH =
+# SSH
 
 This bundle installs ssh software on a node.
 
@@ -192,31 +192,29 @@ The following clases can be set via def.cf/json:
  *  use_depricated_options:  These options are not used anymore , default true  on centos and debian_7
  *  keygen: Must we generate host keys, command line options can bet set via json
 
-== Usage ==
+## Usage
 
 This is called with:
- * `"" usebundle => ssh_autorun();
+ * `"" usebundle => ssh_autorun();`
 
 When we do not specifiy any json data files then only `default.json` will be
 read. You can specify extra json data file via:
  * def.cf
-{{{
-#!cf3
+```
     any::
         "ssh_json_files" slist => { "policy_server.json" };
-}}}
+```
 
 The variable must be ''ssh_json_files'' and with this setup 1 extra json file will be  merged.
 
-=== DEBUG ===
+### DEBUG
 
 if you want to debug this bundle set the `DEBUG_ssh` class, eg:
  * `DDEBUG_ssh`
 
-== Setup ==
+## Setup
 The variables are set in default.json and can be overwritten.
-{{{
-#!json
+```#json
 {
     "AddressFamily": "any",
     "AllowTcpForwarding": "yes",
@@ -293,51 +291,46 @@ The variables are set in default.json and can be overwritten.
     "X11DisplayOffset": "10" ,
     "X11Forwarding": "yes"
 }
-}}}
+```
 
-=== copy_files ===
+### copy_files
 
 When this variable is set it will coyy the specified file to the `ssh.config_dir`. copy_files has the
 following format:
-{{{
-#!json
+```#json
 "": [
 {
     "dest": "Destination path with filename",
-    "src": "The filename path on the policy server/cf-hub",
-    "mode":  "The mode bits",
-    "owner": "File owner",
-    "group": "File group",
+    "source": "The filename path on the policy server/cf-hub",
+    "mog": [ "mode", "owner", "group" ]
     "run_bundle": "This bundle will run if the file gets copied"
 }
 ]
-}}}
+```
 
 example:
-{{{
-#!json
+```#json
 "copy_files": [
     {
         "dest": "$(ssh.config_dir)/shosts.equiv",
-        "src": "cf_bundles_dir/ssh/lisa/shosts.equiv",
-        "mode": "0644", "owner": "root", "group": "root",
+        "source": "cf_bundles_dir/ssh/lisa/shosts.equiv",
+        "mog": [ "0644", "root", "root" ]
     },
     {
         "dest": "$(ssh.config_dir)/ssh_known_hosts2",
-        "src": "cf_bundles_dir/ssh/lisa/ssh_known_hosts2",
-        "mode": "0644", "owner": "root", "group": "root",
+        "source": "cf_bundles_dir/ssh/lisa/ssh_known_hosts2",
+        "mog": [ "0644", "root", "root" ],
         "run_bundle": "ssh_daemons_restart"
     }
 }
-}}}
+```
 
 where `cf_bundles_dir` is a ''cf-serverd shortcut''.
 
-== Def usage  ==
+## Def usage
 
 The following must be set in the specific ''def.json'' hostfile
-{{{
-#!json
+```#json
     "vars": {
         "sara_services_enabled": {
             ...
@@ -347,18 +340,16 @@ The following must be set in the specific ''def.json'' hostfile
         "ssh": {
         }
     },
-}}}
+```
 
 Here are some examples how to use it:
  * specify ssh configuration in def.cf:
-{{{
-#!cf3
+```
 vars:
     "ssh_json_files" slist => { "policy_server.json" };
-}}}
+```
  * Set/Override the daemon options variable in ''def.json'':
-{{{
-#!json
+```#json
         "ssh" : {
             "classes": {
                 "keygen": [ "any" ]
@@ -366,12 +357,10 @@ vars:
             "MaxAuthTries": "6",
             "X11Forwarding": "no",
         },
-}}}
+```
  * override server setting in def.cf
-{{{
-#!cf3
+```
 vars:
     "ssh" data => parsejson( '{ "X11Forwarding":  "no"  }' );
-}}}
-
+```
 @endif

--- a/templates/munge/json/default.json
+++ b/templates/munge/json/default.json
@@ -1,3 +1,3 @@
 {
-    "copy_files": [],
+    "copy_files": []
 }

--- a/templates/node_exporter/json/surfsara.json
+++ b/templates/node_exporter/json/surfsara.json
@@ -5,6 +5,7 @@
         {
             "dest": "$(sara_data.node_exporter[dir])",
             "exclude_dirs": [ ".git", ".svn" ],
+            "mog": [ "0755", "root", "root" ],
             "run_bundle": "node_exporter_restart",
             "source": "cf_bundles_dir/prometheus_exporters/node_exporter-0.15.2"
         }

--- a/templates/nvidia_gpu_prometheus_exporter/json/default.json
+++ b/templates/nvidia_gpu_prometheus_exporter/json/default.json
@@ -5,6 +5,7 @@
         {
             "dest": "$(sara_data.nvidia_gpu_prometheus_exporter[dir])",
             "exclude_dirs": [ ".git", ".svn" ],
+            "mog": [ "0755", "root", "root" ],
             "purge": "true",
             "run_bundle": "nvidia_gpu_prometheus_exporter_restart",
             "source": "cf_bundles_dir/prometheus_exporters/nvidia_gpu_prometheus_exporter-1.0"

--- a/templates/slurm_prometheus_exporter/json/default.json
+++ b/templates/slurm_prometheus_exporter/json/default.json
@@ -5,7 +5,9 @@
         {
             "dest": "$(sara_data.slurm_prometheus_exporter[dir])",
             "exclude_dirs": [ ".git", ".svn" ],
+            "mog": [ "0755", "root", "root" ],
             "purge": "true",
+            "mog": [ "0755", "root", "root" ],
             "run_bundle": "slurm_prometheus_exporter_restart",
             "source": "cf_bundles_dir/prometheus_exporters/slurm_prometheus_exporter-1.0"
         }

--- a/templates/ssh/json/copy_files.json
+++ b/templates/ssh/json/copy_files.json
@@ -1,9 +1,28 @@
 {
-    "copy_files": {
-        "ssh_host_dsa_key": { "source": "cf_bundles_dir/ssh/doornode", "mode": "0600", "owner": "root", "group": "root", "restart": "yes" },
-        "ssh_host_dsa_key.pub": { "source": "cf_bundles_dir/ssh/doornode", "mode": "0644", "owner": "root", "group": "root", "restart": "yes" },
-        "ssh_host_rsa_key": { "source": "cf_bundles_dir/ssh/doornode", "mode": "0600", "owner": "root", "group": "root", "restart": "yes" },
-        "ssh_host_rsa_key.pub": { "source": "cf_bundles_dir/ssh/doornode", "mode": "0644", "owner": "root", "group": "root", "restart": "yes" }
-
+    "copy_files": [
+        {
+            "dest": "$(ssh.config_dir)/ssh_host_dsa_key",
+            "source": "cf_bundles_dir/ssh/doornode",
+            "mog": [ "0600", "root", "root" ],
+            "run_bundle": "ssh_daemons_restart"
+        },
+        {
+            "dest": "$(ssh.config_dir)/ssh_host_dsa_key.pub",
+            "source": "cf_bundles_dir/ssh/doornode",
+            "mog": [ "0644", "root", "root" ],
+            "run_bundle": "ssh_daemons_restart"
+        },
+        {
+            "dest": "$(ssh.config_dir)/ssh_host_rsa_key",
+            "source": "cf_bundles_dir/ssh/doornode",
+            "mog": [ "0644", "root", "root" ],
+            "run_bundle": "ssh_daemons_restart"
+        },
+        {
+            "dest": "$(ssh.config_dir)/ssh_host_rsa_key",
+            "source": "cf_bundles_dir/ssh/doornode",
+            "mog": [ "0644", "root", "root" ],
+            "run_bundle": "ssh_daemons_restart"
+        }
     }
 }


### PR DESCRIPTION
copy_files and copy_dirs are now using the same names for:
 * source definition, namely: `source`
 * mode, owner, group settings, namely mog : [ 0644, root, root ]

Converted all services to this new format.