### PR TITLE
Update from  SURFsara prod environment

### DIFF
--- a/masterfiles/lib/surfsara/packages.cf
+++ b/masterfiles/lib/surfsara/packages.cf
@@ -41,6 +41,7 @@ Another example is to install and remove ssh packages in 'def.json':
 
 The following package actions are implemented:
  * install : install the package
+ * install_backports : install the package from backports (Debian)
  * purge: delete the package and all it configuration files
  * remove: delete the package and preserve the configuration files
 @endif
@@ -118,7 +119,39 @@ bundle agent sara_service_packages_install(bundle_name, pkg_data)
 
     reports:
         any::
-            "$(this.bundle) has beeen called"
+            "$(this.bundle) has been called"
+                ifvarclass => "DEBUG_$(bundle_name)|DEBUG|DEBUG_MUSTACHE_JSON|DEBUG_MUSTACHE";
+}
+
+bundle agent sara_service_packages_install_backports(bundle_name, pkg_data)
+{
+    vars:
+        any::
+            "packages" slist => getindices("pkg_data[install_backports]");
+
+@if minimum_version(3.12)
+        debian::
+            "release" string => regex_replace("$(sys.os_release[VERSION])", ".*\((\w+).*", "\1", "");
+            "pkg_options" string => "--target-release=$(release)-backports";
+@endif
+
+        (!debian|cfengine_3_7|cfengine_3_10)::
+            "pkg_options" string => "";
+
+    methods:
+        any::
+            "" usebundle => sara_service_package("$(bundle_name)",
+                "$(packages)", "$(pkg_data[install_backports][$(packages)])", "present", "$(pkg_options)");
+
+    reports:
+        any::
+            "$(this.bundle) has been called"
+                ifvarclass => "DEBUG_$(bundle_name)|DEBUG|DEBUG_MUSTACHE_JSON|DEBUG_MUSTACHE";
+        (cfengine_3_7|cfengine_3_10)::
+            "$(this.bundle) is not supported on versions lower than CFEngine 3.12, falling back to normal install"
+                ifvarclass => "DEBUG_$(bundle_name)|DEBUG|DEBUG_MUSTACHE_JSON|DEBUG_MUSTACHE";
+        !debian::
+            "$(this.bundle) is only supported on Debian, falling back to normal install"
                 ifvarclass => "DEBUG_$(bundle_name)|DEBUG|DEBUG_MUSTACHE_JSON|DEBUG_MUSTACHE";
 }
 
@@ -157,7 +190,7 @@ bundle agent sara_service_packages_purge(bundle_name, pkg_data)
 
     reports:
         any::
-            "$(this.bundle) has beeen called"
+            "$(this.bundle) has been called"
                 ifvarclass => "DEBUG_$(bundle_name)|DEBUG|DEBUG_MUSTACHE_JSON|DEBUG_MUSTACHE";
 }
 

--- a/services/apt.cf
+++ b/services/apt.cf
@@ -287,11 +287,11 @@ bundle agent apt_repository()
         !apt_repository_json_files_set::
             "repo_files" slist => { getvalues("sara_data.apt[repo_files]") };
         apt_repository_json_files_set::
-            "repo_files" slist => { getvalues("sara_data.apt[repo_files]"), "@(def.apt_repository_json_files)" },
+            "repo_files" slist => { getvalues("sara_data.apt[repo_files]"), "@(def.apt_repo_files)" },
                 comment => "Support old behaviour till we converted everything to new apt setup";
 
     classes:
-        "apt_repository_json_files_set" expression => isvariable("def.apt_repository_json_files"),
+        "apt_repository_json_files_set" expression => isvariable("def.apt_repo_files"),
                 comment => "Support old behaviour till we converted everything to new apt setup";
 
     methods:

--- a/templates/ssh/sshd_banner.mustache
+++ b/templates/ssh/sshd_banner.mustache
@@ -1,6 +1,8 @@
                               SURFsara
-        
+
                         Welcome to {{vars.sara_data.ssh.Banner_system}}
+
+{{vars.sara_data.ssh.Banner_system_warning}}
 
    This is a private computer facility.   Access for any reason must be
    specifically authorized by the owner.  Unless you are so authorized,


### PR DESCRIPTION
Fixed munge.cf syntax error

slurm service update
 * Do not "purge" packages anymore
 * added a new class SLURMD_DISABLE (disable systemd slurmd service)
 * Move surfsara specific commands to cluster files
 * Bump default Slurm version to 18.08.5-2
 * version definition for libslurmdb

apt service bundle enhancements
 * added backports option for debian
 * added meta keywords
 * apt_check enhancements
 * apt_repo_json_files instead of apt_repository_json_files

ssh service bundle enhancements:
 * Addded Banner_system_warning

Added a new CFEngine bundle for configuring rsyslog