### PR TITLE
Added dirmgr in apt.packages

### DIFF
--- a/services/apt.cf
+++ b/services/apt.cf
@@ -14,8 +14,9 @@ bundle common apt
 
             "packages"  data => parsejson('{
                 "install": {
-                    "debconf-utils": ""
-                    "apt-transport-https": ""
+                    "debconf-utils": "",
+                    "apt-transport-https": "",
+                    "dirmngr": ""
                 }
             }');
 


### PR DESCRIPTION
Added dirmgr, this package is required when importing keys with gpg. Also fixed to proper json format