### PR TITLE
Removed ssh-blacklist and added node_exporter method

### DIFF
--- a/services/node_exporter.cf
+++ b/services/node_exporter.cf
@@ -101,6 +101,14 @@ bundle agent node_exporter_daemon_check()
            ifvarclass => "DEBUG|DEBUG_node_exporter|DEBUG_$(this.bundle)";
 }
 
+bundle agent node_exporter_service_status(service, status)
+{
+    commands:
+        "/usr/bin/echo"
+            args => "-e 'surfsara_service{name=\"$(service)\"} $(status)\n' > $(sara_data.node_exporter[collector_dir])/surfsara_service_$(service).prom",
+            contain => in_shell_and_silent;
+}
+
 bundle agent node_exporter_autorun()
 {
     meta:

--- a/services/ssh.cf
+++ b/services/ssh.cf
@@ -29,8 +29,7 @@ bundle common ssh()
                     {
                         "install": {
                             "openssh-client" : "",
-                            "openssh-server" : "",
-                            "openssh-blacklist" : ""
+                            "openssh-server" : ""
                         }
                     }
                 ');


### PR DESCRIPTION
 * The ssh-blacklist packages is removed in Debian 9, so do not try to install it
 * Added a method for writing prom files for node_exporter to display the service status, it uses the following name for the metric
  * `surfsara_service`