### PR TITLE
Added a new service apache

### DIFF
--- a/services/apache.cf
+++ b/services/apache.cf
@@ -1,0 +1,175 @@
+
+bundle common apache
+{
+    vars:
+        "configdir" string => "/opt/apache";
+
+        "performance_profile" string => "l_4c8m";
+
+        "service_name" string => "apache2";
+        "daemon_name" string => "apache2";
+
+        "restart" string => "$(paths.path[systemctl]) restart $(service_name)";
+
+        "packages"  data => parsejson('
+            {
+                "install": {
+                    "apache2": "",
+                }
+            }
+        ');
+
+        "template_2_destination" data => parsejson('
+            {   
+                "envvars.mustache": "/etc/apache2/envvars",
+                "httpd.conf.mustache": "$(configdir)/httpd.conf"
+                "ssl.conf.mustache": "$(configdir)/ssl.conf"
+                "server.conf.mustache": "$(configdir)/server.conf"
+            }   
+        '); 
+
+}
+
+bundle agent apache_install()
+{
+    methods:
+        "" usebundle => sara_service_packages("apache", "@(apache.packages)");
+}
+
+bundle agent apache_config()
+{
+    classes:
+        "apache_config_dir_exists" expression => isdir("$(sara_data.apache[configdir])");
+        "apache_restart" or => {
+            "APACHE_MODULES_repaired",
+            "APACHE_SITES_repaired",
+            "sara_opt_apache_httpd_conf",
+            "sara_opt_apache_server_conf",
+            "sara_opt_apache_ssl_conf",
+            "sara_opt_apache_envvars"
+        };
+
+    vars:
+        "apache_modules_index" slist => getindices("sara_data.apache[modules]");
+        "apache_modules" data => parsejson('[]');
+        "apache_modules" data => mergedata("apache_modules", parsejson('["$(sara_data.apache[modules][$(apache_modules_index)][config_file])"]'));
+
+        "apache_dirs_needed" slist => { 
+            "$(sara_data.apache[configdir])/modules.d", 
+            "$(sara_data.apache[configdir])/sites.d",
+            "$(sara_data.apache[document_root])",
+            "$(sara_data.apache[sites_root])"
+        };
+
+    files:
+        "$(sara_data.apache[configdir])/."
+            perms => mog("755", "$(sara_data.apache[user])", "$(sara_data.apache[group])"),
+            create => "true",
+            move_obstructions => "true",
+            classes => results("namespace", "APACHE_CONFIGDIR"),
+            ifvarclass => not("apache_config_dir_exists");
+
+        "$(apache_dirs_needed)/."
+            perms => mog("755", "$(sara_data.apache[user])", "$(sara_data.apache[group])"),
+            create => "true",
+            move_obstructions => "true",
+            classes => results("namespace", "$(apache_dirs_needed)"),
+            ifvarclass => "apache_config_dir_exists";
+
+        "$(sara_data.apache[configdir])/modules.d/$(apache_modules)"
+            perms => mog("644", "$(sara_data.apache[user])", "$(sara_data.apache[group])"),
+            copy_from => sara_sync_cp("cf_bundles_dir/apache/modules_config/$(apache_modules)", "hash"),
+            move_obstructions => "true",
+            classes => results("namespace", "APACHE_MODULES"),
+            ifvarclass => "apache_config_dir_exists";
+
+        "$(sara_data.apache[configdir])/sites.d/$(sara_data.apache[sites])"
+            perms => mog("644", "$(sara_data.apache[user])", "$(sara_data.apache[group])"),
+            copy_from => sara_sync_cp("cf_bundles_dir/apache/sites/$(sara_data.apache[sites])", "hash"),
+            move_obstructions => "true",
+            classes => results("namespace", "APACHE_SITES"),
+            ifvarclass => "apache_config_dir_exists";
+
+        ## TODO delete sites.d and modules.d files when not needed
+
+    methods:
+        "" usebundle => sara_mustache_autorun("apache"),
+            ifvarclass => or(
+                "apache_config_dir_exists",
+                "APACHE_CONFIGDIR_repaired"
+            );
+
+    commands:
+        "$(apache.restart)"
+            ifvarclass => "apache_restart";
+}
+
+bundle agent apache_daemon_check()
+{
+    processes:
+        "$(apache.daemon_name)"
+            comment => "Check if Grafana is running",
+            process_count   => check_range("$(apache.daemon_name)", "1", "1"),
+            process_select  => sara_select_parent_process("1");
+
+    commands:
+        "$(apache.restart)"
+            ifvarclass => canonify("$(apache.daemon_name)_out_of_range");
+}
+
+bundle agent apache_autorun()
+{
+    meta:
+        "tags" slist => { "autorun", "template_apache" };
+
+    methods:
+        debian::
+            "" usebundle => sara_data_autorun("apache");
+            "" usebundle => apache_install();
+            "" usebundle => apache_config();
+            "" usebundle => apache_daemon_check();
+}
+
+@if minimum_version(99.9)
+# apache.cf
+
+Source[apache.cf](/services/apache.cf)
+
+This bundle will be used to:
+ * Configure Apache in /opt/apache so when updating/upgrading Apache you won't conflict with the distribution setup
+ * Simplified setup so it's easier to use with CFEngine
+ * Still free formatting of Apache code for modules and sites
+ * Only configures Apache, for Python wsgi and/or PHP a separate service needs to be created
+
+Please note that this bundle has only been tested/designed for Debian Stretch or Buster. And therefor a specific 
+Debian Apache file envvars wil be written to `/etc/apache2/envvars`. This is needed to make sure Apache daemon
+uses the `/opt/apache/httpd.conf` instead of the default configuration file.
+
+TODO:
+ - Desining separate services for Python wsgi and PHP
+ - A construction need to be design for easy switching between "Performance" profiles based on a value of the machine
+
+## Usage
+
+The bundle can be run via:
+ *  `"" usebundle => apache_autorun();`
+ * `def.sara_services_enabled` (prefered)
+```json
+"vars": {
+    "sara_services_enabled": [
+            "...",
+            "apache",
+            "..."
+    ]   
+}
+```
+
+The bundle will aways read the [default.json](/templates/apache/json/default.json) file
+and extra json file(s) can be specified via:
+ * def.cf
+```
+vars:
+    any::
+        "apt_json_files" slist => { "debconf.json" };
+```
+@endif

--- a/templates/apache/envvars.mustache
+++ b/templates/apache/envvars.mustache
@@ -1,0 +1,52 @@
+####
+# This file is Maintained by CFEngine
+#
+
+# envvars - default environment variables for apache2ctl
+
+# this won't be correct after changing uid
+unset HOME
+
+# for supporting multiple apache2 instances
+if [ "${APACHE_CONFDIR##/etc/apache2-}" != "${APACHE_CONFDIR}" ] ; then
+    SUFFIX="-${APACHE_CONFDIR##/etc/apache2-}"
+else
+    SUFFIX=
+fi
+
+# Since there is no sane way to get the parsed apache2 config in scripts, some
+# settings are defined via environment variables and then used in apache2ctl,
+# /etc/init.d/apache2, /etc/logrotate.d/apache2, etc.
+export APACHE_RUN_USER={{{vars.sara_data.apache.user}}}
+export APACHE_RUN_GROUP={{{vars.sara_data.apache.group}}}
+
+# temporary state file location. This might be changed to /run in Wheezy+1
+export APACHE_PID_FILE=/var/run/apache2$SUFFIX/apache2.pid
+export APACHE_RUN_DIR=/var/run/apache2$SUFFIX
+export APACHE_LOCK_DIR=/var/lock/apache2$SUFFIX
+# Only /var/log/apache2 is handled by /etc/logrotate.d/apache2.
+export APACHE_LOG_DIR=/var/log/apache2$SUFFIX
+
+## The locale used by some modules like mod_dav
+export LANG=C
+## Uncomment the following line to use the system default locale instead:
+#. /etc/default/locale
+
+export LANG
+
+## The command to get the status for 'apache2ctl status'.
+## Some packages providing 'www-browser' need '--dump' instead of '-dump'.
+#export APACHE_LYNX='www-browser -dump'
+
+## If you need a higher file descriptor limit, uncomment and adjust the
+## following line (default is 8192):
+#APACHE_ULIMIT_MAX_FILES='ulimit -n 65536'
+
+## If you would like to pass arguments to the web server, add them below
+## to the APACHE_ARGUMENTS environment.
+export APACHE_ARGUMENTS='{{{vars.sara_data.apache.args_arguments}}}'
+
+## Enable the debug mode for maintainer scripts.
+## This will produce a verbose output on package installations of web server modules and web application
+## installations which interact with Apache
+#export APACHE2_MAINTSCRIPT_DEBUG=1

--- a/templates/apache/httpd.conf.mustache
+++ b/templates/apache/httpd.conf.mustache
@@ -1,0 +1,86 @@
+#####
+# This file is maintained by CFEngine
+
+# Overview of the used configuration files and layout
+
+# httpd.conf
+#  |  (uid, server-tuning, loadmodules, listen)
+#  |-- ssl.conf
+#  |  (global ssl settings, not confugureable with json!)
+#  |-- modules.d/*.conf
+#  |  (module specific configs)
+#  |-- server.conf
+#  |  (default_server, errors)
+#  |-- vhost.d/*.conf
+#     (the sites config)
+
+## We are not using the default location
+ServerRoot "{{{vars.sara_data.apache.configdir}}}"
+
+## Uid
+User {{{vars.sara_data.apache.user}}}
+Group {{{vars.sara_data.apache.user}}}
+
+## Server-tuning
+# We only configure the MPM Event engine
+<IfModule mpm_event_module>
+    ServerLimit                 {{{vars.sara_data.apache.tuning_servers_limit}}}            
+    MaxRequestWorkers           {{{vars.sara_data.apache.tuning_max_workers}}}
+    StartServers                {{{vars.sara_data.apache.tuning_start_servers}}}
+    ThreadsPerChild             {{{vars.sara_data.apache.tuning_threads_p_child}}}
+    ThreadLimit                 {{{vars.sara_data.apache.tuning_threads_limit}}}
+</IfModule>
+
+## Loadmodule
+{{#vars.sara_data.apache.modules}}
+LoadModule {{{name}}}_module /usr/lib/apache2/modules/mod_{{{name}}}.so
+{{/vars.sara_data.apache.modules}}
+IncludeOptional {{{vars.sara_data.apache.configdir}}}/modules.d/*.conf
+
+## Listen
+Listen 80
+Listen 443
+
+## Mod_log config
+#         Format string:                        Nickname:
+LogFormat "%h %l %u %t \"%r\" %>s %b"           common
+LogFormat "%v %h %l %u %t \"%r\" %>s %b"        vhost_common
+LogFormat "%{Referer}i -> %U"                   referer
+LogFormat "%{User-agent}i"                      agent
+LogFormat "%h %l %u %t \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\""             combined
+LogFormat "%v %h %l %u %t \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\""             vhost_combined
+Logformat "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+\"%r\" %b"                                      ssl_common
+Logformat "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+\"%r\" %b \"%{Referer}i\" \"%{User-Agent}i\""   ssl_combined
+
+# To use %I and %O, you need to enable mod_logio
+<IfModule mod_logio.c>
+LogFormat "%h %l %u %t \"%r\" %>s %b \
+\"%{Referer}i\" \"%{User-Agent}i\" %I %O"       combinedio
+</IfModule>
+
+<FilesMatch "^\.ht">
+    Require all denied
+</FilesMatch>
+
+# Use one of these when you want a compact non-error SSL logfile on a virtual
+# host basis:
+
+## Global
+ServerSignature off
+UseCanonicalName off
+ServerTokens ProductOnly
+LogLevel warn
+
+ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog ${APACHE_LOG_DIR}/access_log combined
+
+## For better oveview the following stuff has configured in it's own file
+Include {{{vars.sara_data.apache.configdir}}}/ssl.conf
+Include {{{vars.sara_data.apache.configdir}}}/server.conf
+
+## Finally include the sites.d
+IncludeOptional {{{vars.sara_data.apache.configdir}}}/sites.d/*.conf

--- a/templates/apache/json/default.json
+++ b/templates/apache/json/default.json
@@ -1,0 +1,108 @@
+{
+    "configdir": "/opt/apache",
+    "user": "www-data",
+    "group": "www-data",
+    "document_root": "/srv/www/htdocs",
+    "sites_root": "/srv/sites",
+    "tuning_servers_limit": "8",
+    "tuning_max_workers": "200",
+    "tuning_start_servers": "3",
+    "tuning_threads_p_child": "25",
+    "tuning_threads_limit": "64",
+    "logdir": "/var/log",
+    "modules": [
+        {
+            "name": "access_compat", "config_file": ""
+        },
+        {
+            "name": "alias", "config_file": "alias.conf"
+        },
+        {
+            "name": "auth_basic", "config_file": ""
+        },
+        {
+            "name": "authn_core", "config_file": ""
+        },
+        {
+            "name": "authn_file", "config_file": ""
+        },
+        {
+            "name": "authz_core", "config_file": ""
+        },
+        {
+            "name": "authz_host", "config_file": ""
+        },
+        {
+            "name": "authz_user", "config_file": ""
+        },
+        {
+            "name": "autoindex", "config_file": "autoindex.conf"
+        },
+        {
+            "name": "deflate", "config_file": "deflate.conf"
+        },
+        {
+            "name": "dir", "config_file": "dir.conf"
+        },
+        {
+            "name": "env", "config_file": ""
+        },
+        {
+            "name": "headers", "config_file": ""
+        },
+        {
+            "name": "http2", "config_file": "http2.conf"
+        },
+        {
+            "name": "filter", "config_file": ""
+        },
+        {
+            "name": "mime", "config_file": "mime.conf"
+        },
+        {
+            "name": "mime_magic", "config_file": "mime_magic.conf"
+        },
+        {
+            "name": "mpm_event", "config_file": ""
+        },
+        {
+            "name": "negotiation", "config_file": "negotiation.conf"
+        },
+        {
+            "name": "proxy", "config_file": ""
+        },
+        {
+            "name": "proxy_fcgi", "config_file": "proxy_fcgi.conf"
+        },
+        {
+            "name": "proxy_http", "config_file": ""
+        },
+        {
+            "name": "proxy_wstunnel", "config_file": ""
+        },
+        {
+            "name": "reqtimeout", "config_file": "reqtimeout.conf"
+        },
+        {
+            "name": "rewrite", "config_file": "reqtimeout.conf"
+        },
+        {
+            "name": "setenvif", "config_file": ""
+        },
+        {
+            "name": "ssl", "config_file": ""
+        },
+        {
+            "name": "socache_shmcb", "config_file": ""
+        },
+        {
+            "name": "status", "config_file": ""
+        },
+        {
+            "name": "wsgi", "config_file": ""
+        }
+    ],
+    "args_arguments": "-f $(sara_data.apache[configdir])/httpd.conf",
+    "sites": []
+}
+

--- a/templates/apache/server.conf.mustache
+++ b/templates/apache/server.conf.mustache
@@ -1,0 +1,15 @@
+#####
+# This file is maintained by CFEngine
+
+DocumentRoot "{{{vars.sara_data.apache.document_root}}}"
+<Directory "{{{vars.sara_data.apache.document_root}}}">
+    Options None
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<VirtualHost *:80>
+    RewriteEngine On 
+    RewriteCond %{HTTPS}  !=on 
+    RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L] 
+</VirtualHost>

--- a/templates/apache/ssl.conf.mustache
+++ b/templates/apache/ssl.conf.mustache
@@ -1,0 +1,39 @@
+#####
+# This file is maintained by CFEngine
+
+<IfModule mod_ssl.c>
+    SSLRandomSeed startup builtin
+    SSLRandomSeed startup file:/dev/urandom 512
+    SSLRandomSeed connect builtin
+    SSLRandomSeed connect file:/dev/urandom 512
+
+    AddType application/x-x509-ca-cert .crt
+    AddType application/x-pkcs7-crl .crl
+
+    SSLPassPhraseDialog  exec:/usr/share/apache2/ask-for-passphrase
+
+    SSLSessionCache     shmcb:${APACHE_RUN_DIR}/ssl_scache(512000)
+    SSLSessionCacheTimeout  300
+
+    SSLCompression off
+
+    SSLProtocol All -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+
+    ## TLSv1.1 and TLSv1.2
+    SSLCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA
+
+    ## TLSv1.2 only!!
+    #SSLCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-GCM-SHA384
+
+    SSLHonorCipherOrder on
+
+
+    SSLUseStapling on
+    SSLStaplingCache shmcb:${APACHE_RUN_DIR}/ssl_staple_cache(512000)
+
+    Header always set Strict-Transport-Security "max-age=31556952"
+    Header always setifempty Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline' *.bootstrapcdn.com *.cloudflare.com fonts.googleapis.com estudybooks.surf.nl; script-src 'self' 'unsafe-inline' 'unsafe-eval' webstats.surf.nl code.jquery.com *.bootstrapcdn.com *.cloudflare.com; img-src 'self' 'unsafe-inline' https: data: webstats.surf.nl; font-src 'self' data: *.bootstrapcdn.com fonts.gstatic.com"
+    Header always setifempty X-Frame-Options "SAMEORIGIN"
+    Header always setifempty X-Xss-Protection "1; mode=block"
+    Header always setifempty X-Content-Type-Options "nosniff"
+</IfModule>


### PR DESCRIPTION
Main features of this service is:
 * Optimized for Debian Stretch/Buster
 * The SSL settings are based on some best practices
 * Configuration has been separated from the distribution setup, so it's easier to be deployed with CFEngine

This service bundle can be used in production, but things are still in the backlog:
 - Multiple performance profiles which can be chosen based on a feature of the machine where Apache is running
 - Separate service for Python (wsgi) and PHP (fpm)