### PR TITLE
synced with SURF production environment

### DIFF
--- a/masterfiles/lib/surfsara/files.cf
+++ b/masterfiles/lib/surfsara/files.cf
@@ -339,6 +339,12 @@ bundle agent sara_service_install_tarballs(bundle_name)
                 if => or(
                     "DEBUG|DEBUG_$(bundle_name)|DEBUG_$(this.bundle)"
                     );
+
+            "$(this.bundle): Software directory does not exists: $(sara_data.$(bundle_name)[install_tarballs][$(index)][check_dir]) force reinstall"
+                if => and(
+                    "DEBUG|DEBUG_$(bundle_name)|DEBUG_$(this.bundle)",
+                    "!check_dir_$(index)"
+                    );
 }
 
 bundle agent sara_service_copy_base(bundle_name, section)

--- a/services/slurm.cf
+++ b/services/slurm.cf
@@ -115,6 +115,7 @@ bundle agent slurm_install()
 
         SLURM_TARBALL::
             "" usebundle => slurm_install_tarball();
+            "" usebundle => slurm_current_version();
 
         SLURM_SYSTEMD_SERVICES|SLURM_TARBALL::
             "" usebundle => slurm_generate_systemd_services();
@@ -169,11 +170,6 @@ $(slurm.software_dir)/current/lib/slurm
 
     files:
         any::
-            "$(slurm.software_dir)/current"
-                link_from => ln_s("$(slurm.software_dir)/$(slurm.current_version)"),
-                move_obstructions => "true",
-                classes => results("bundle", "current_version");
-
             "/etc/ld.so.conf.d/slurm.conf"
                 create => "true",
                 edit_defaults => no_backup,
@@ -188,20 +184,6 @@ $(slurm.software_dir)/current/lib/slurm
             "$(slurm.software_dir)/."
                 perms => mog("0755", "root", "root"),
                 create => "true";
-
-
-        slurm_tarball_repaired|current_version_repaired|SLURM_FORCE_LINKS::
-             "/usr/bin"
-                comment => "slurm client program link them in /usr/bin",
-                link_from => linkchildren("$(slurm.software_dir)/current/bin");
-
-             "/usr/sbin"
-                comment => "slurm client program link them in /usr/sbin",
-                link_from => linkchildren("$(slurm.software_dir)/current/sbin");
-
-             "$(pam.lib_dir)/pam_slurm_adopt.so"
-                copy_from   => local_dcp("$(slurm.software_dir)/current/pam/pam_slurm_adopt.so"),
-                perms => mog("0755", "root", "root");
 
     methods:
         any::
@@ -226,7 +208,31 @@ $(slurm.software_dir)/current/lib/slurm
 
             "$(paths.path[groupadd]) --gid $(slurm.gid) $(slurm.group)"
                 if => "!slurm_grp";
+}
 
+bundle agent slurm_current_version()
+{
+    files:
+        any::
+            "$(slurm.software_dir)/current"
+                link_from => ln_s("$(slurm.software_dir)/$(slurm.current_version)"),
+                move_obstructions => "true",
+                classes => results("bundle", "current_version");
+
+        current_version_repaired|SLURM_FORCE_LINKS::
+             "/usr/bin"
+                comment => "slurm client program link them in /usr/bin",
+                link_from => linkchildren("$(slurm.software_dir)/current/bin");
+
+             "/usr/sbin"
+                comment => "slurm client program link them in /usr/sbin",
+                link_from => linkchildren("$(slurm.software_dir)/current/sbin");
+
+             "$(pam.lib_dir)/pam_slurm_adopt.so"
+                copy_from   => local_dcp("$(slurm.software_dir)/current/pam/pam_slurm_adopt.so"),
+                perms => mog("0755", "root", "root");
+
+    commands:
         SLURM_CLIENT.current_version_repaired::
             "$(slurm.restart_client)";
 }

--- a/templates/jupyterhub/jupyterhub_example.mustache
+++ b/templates/jupyterhub/jupyterhub_example.mustache
@@ -28,6 +28,13 @@ c.Application.log_level = 'DEBUG'
 #  Users should be properly informed if this is enabled.
 c.JupyterHub.admin_access = False
 
+### MOTD announcements
+<%#announcements%>
+c.JupyterHub.template_vars = {
+    '<%@%>' : '<b><%.%></b>',
+}
+<%/announcements%>
+
 c.JupyterHub.authenticator_class = 'jupyterhub.auth.PAMAuthenticator'
 c.PAMAuthenticator.admin_groups = { <%#admin_groups%> <%.%> <%/admin_groups%> }
 c.PAMAuthenticator.service = "<%pam_service_file%>"

--- a/templates/slurm/slurm.mustache
+++ b/templates/slurm/slurm.mustache
@@ -31,7 +31,6 @@ TmpFS={{{vars.sara_data.slurm.tmpfs}}}
 
 #ProctrackType=proctrack/pgid
 ProctrackType=proctrack/cgroup
-CacheGroups=0
 ReturnToService=1
 #UnkillableStepTimeout=600
 #UnkillableStepProgram="scontrol update NodeName=$(hostname -s) State=down Reason=hung_proc"


### PR DESCRIPTION
jupyterhub:
 - Added announement options , eg:  announce maintenance

slurm:
 - removed obsolete option: CacheGroups
 - symplified current version check

masterfiles/lib/surfsara/files.cf:
 - Added a verbise message for tarball installtions if software dir
   does not exists