### PR TITLE
Install SCL modules to the right directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 <!-- vim-markdown-toc GFM -->
 
+* [Version: 0.9.89 (2021-03-28)](#version-0989-2021-03-28)
 * [Version: 0.9.88 (2021-03-16 Dre)](#version-0988-2021-03-16-dre)
 * [Version: 0.9.82 (2020-12-05 sint)](#version-0982-2020-12-05-sint)
 * [Version: 0.9.77 (2020-07-14 tommie)](#version-0977-2020-07-14-tommie)
@@ -21,6 +22,11 @@
 * [Version: 0.9.0 (2018-08-24)](#version-090-2018-08-24)
 
 <!-- vim-markdown-toc -->
+# Version: 0.9.89 (2021-03-28)
+
+Fixed an installation error in `mpf_installation` script. The surfsara modules were copied to the
+wrong directort was `/var/cfengine/modules` instead of `/var/cfengine/masterfiles/modules`
+
 # Version: 0.9.88 (2021-03-16 Dre)
  * apache service changes:
     * Use `data` shortcut for copying files (is cfengine standard)

--- a/mpf_installation
+++ b/mpf_installation
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 ## Some defaults can be overriden by command line opts
 #
 CFENGINE_DIR=/var/cfengine
 CFENGINE_MASTERFILES_DIR=$CFENGINE_DIR/masterfiles
 CFENGINE_TEMPLATES_DIR=$CFENGINE_DIR/templates
-CFENGINE_MODULES_DIR=$CFENGINE_DIR/modules
+CFENGINE_MODULES_DIR=$CFENGINE_MASTERFILES_DIR/modules
 
 SURFSARA_LIB="masterfiles/lib/surfsara"
 SURFSARA_AUTORUN_SERVICE="masterfiles/services/autorun/surfsara.cf"
@@ -92,6 +92,14 @@ else
     cp $SURFSARA_SERVICES/* $CFENGINE_SERVICES_DIR/surfsara
 fi
 
+### Modules
+#
+if [ ! -d  $CFENGINE_MODULES_DIR/surfsara ]
+then
+    mkdir $CFENGINE_MODULES_DIR/surfsara
+fi
+cp -a $SURFSARA_MODULES/* $CFENGINE_MODULES_DIR/surfsara
+
 ### Templates and json files
 #
 if [ ! -d  $CFENGINE_TEMPLATES_DIR ]
@@ -99,6 +107,7 @@ then
     mkdir $CFENGINE_TEMPLATES_DIR
 fi
 
+### Must we update templates/json files
 cd  $SURFSARA_TEMPLATES || exit 1
 for d in *
 do
@@ -116,11 +125,3 @@ do
             cp --no-dereference -R $d $CFENGINE_TEMPLATES_DIR
         fi
 done
-
-### Modules
-#
-if [ ! -d  $CFENGINE_MODULES_DIR/surfsara ]
-then
-    mkdir $CFENGINE_MODULES_DIR/surfsara
-fi
-cp -a $SURFSARA_MODULES/* $CFENGINE_MODULES_DIR/surfsara


### PR DESCRIPTION
Must be `/var/cfengine/masterfiles/modules` instead of
`/var/cfengine/modules`