### PR TITLE
Added support for the CFEngine build system (cfbs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
         * [JSON Merge strategy](#json-merge-strategy)
             * [JSON merge example](#json-merge-example)
     * [Installation](#installation)
+        * [CFEngine Build System](#cfengine-build-system)
         * [MPF installation](#mpf-installation)
             * [update](#update)
         * [Own framework](#own-framework)
@@ -113,9 +114,24 @@ The golden rule is to use `<service>_json_files` for the global one and the othe
 
 ## Installation
 
-there are two options
+there are three options
+ * With the new tool [CFEngine Build System](https://github.com/cfengine/cfbs) **prefered method**
  * Include it in the Master Policy Framework (MPF)
  * Include it in your own framework
+
+### CFEngine Build System
+
+With this you can easily test and build masterfiles configuration. The steps to build your masterfiles:
+ * Read the [CFEngine Build System blog](https://cfengine.com/blog/2021/cfengine-build-launched)
+
+I will publish the "module" to teh [CFEngine build catalogue](https://build.cfengine.com). This are the installation
+instructions:
+ * `mkdir scl_masterfiles`
+ * `cfbs init`
+ * `cfbs add masterfiles`
+ * `cfbs add https://github.com/basvandervlies/cf_surfsara_lib`
+ * `cfbs build`
+ * `cfbs install`
 
 ### MPF installation
 
@@ -138,13 +154,14 @@ You can test your installation with
 
 You can run the same script it will detect its an update. This script will overwrite:
  * scl library files: `masterfiles/lib/scl`
+ * scl modules files: `masterfiles/modules/scl`
  * scl services files: `masterfiles/services/scl`
- * mustache template files and default.json files: `/var/cfengine/templates`
 
 ### Own framework
 
 1. Login on your policy server.
 1. `cp -a masterfiles/lib/scl <masterfiles>/lib/scl`
+1. `cp -a modules/ <masterfiles>/modules/scl`
 1. `cp -a templates/\* $(sys.workdir)/templates`
 1. include `/lib/scl/stdlib.cf` in your inputs
 ```

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ there are three options
 With this you can easily test and build masterfiles configuration. The steps to build your masterfiles:
  * Read the [CFEngine Build System blog](https://cfengine.com/blog/2021/cfengine-build-launched)
 
-I will publish the "module" to teh [CFEngine build catalogue](https://build.cfengine.com). This are the installation
+I will publish the "module" to the [CFEngine build catalogue](https://build.cfengine.com). This are the installation
 instructions:
  * `mkdir scl_masterfiles`
  * `cfbs init`

--- a/cfbs.json
+++ b/cfbs.json
@@ -11,10 +11,11 @@
       "dependencies": ["autorun"],
       "steps": [
         "copy ./masterfiles/lib/scl/ lib/scl/",
-        "copy ./templates/ lib/scl/.git",
         "copy ./masterfiles/services/autorun/scl.cf services/autorun/scl.cf",
+        "copy ./modules/ modules/scl/",
+        "copy ./scl_example.json scl_example.json",
         "copy ./services/ services/scl/",
-        "copy ./modules/ modules/scl/"
+        "copy ./templates/ lib/scl/.git/templates"
       ]
     }
   }

--- a/masterfiles/services/autorun/scl.cf
+++ b/masterfiles/services/autorun/scl.cf
@@ -15,11 +15,25 @@ bundle agent scl_autorun {
     meta:
         "tags" slist => { "autorun" };
 
+    vars:
+        policy_server::
+            "template_pattern" slist => { ".*\.mustache", "default\.json" };
+
+    files:
+        policy_server::
+            "$(def.dir_templates)"
+                comment  => "Copy the the scl template dir to the cfengine template dir (shortcut: templates)",
+                copy_from => local_dcp("$(def.dir_masterfiles)/lib/scl/.git/templates"),
+                depth_search => recurse("inf"),
+                file_select => by_name("@(template_pattern)"),
+                move_obstructions => "true";
+
     methods:
-        "" usebundle => scl_inventory_modules(),
-            comment => "Which inventory module must be run, controlled via 'def.scl_inventory_modules'";
-        "" usebundle => scl_services_autorun(),
-            comment => "Which service bundle(s) must be run, controlled via 'def.scl_services_enabled'";
+        any::
+            "" usebundle => scl_inventory_modules(),
+                comment => "Which inventory module must be run, controlled via 'def.scl_inventory_modules'";
+            "" usebundle => scl_services_autorun(),
+                comment => "Which service bundle(s) must be run, controlled via 'def.scl_services_enabled'";
 
     reports:
         verbose_mode::

--- a/mpf_installation
+++ b/mpf_installation
@@ -5,7 +5,6 @@
 CFENGINE_DIR=/var/cfengine
 CFENGINE_MASTERFILES_DIR=$CFENGINE_DIR/masterfiles
 CFENGINE_TEMPLATES_DIR=$CFENGINE_DIR/templates
-CFENGINE_MODULES_DIR=$CFENGINE_MASTERFILES_DIR/modules
 
 SCL_LIB="masterfiles/lib/scl"
 SCL_AUTORUN_SERVICE="masterfiles/services/autorun/scl.cf"
@@ -13,7 +12,6 @@ SCL_AUTORUN_SERVICE="masterfiles/services/autorun/scl.cf"
 SCL_TEMPLATES="templates"
 SCL_SERVICES="services"
 SCL_MODULES="modules"
-
 
 ### Functions
 print_usage()
@@ -28,7 +26,6 @@ do
         CFENGINE_DIR="$OPTARG"
         CFENGINE_MASTERFILES_DIR=$CFENGINE_DIR/masterfiles
         CFENGINE_TEMPLATES_DIR=$CFENGINE_DIR/templates
-        CFENGINE_MODULES_DIR=$CFENGINE_DIR/modules
       ;;
       m)
         CFENGINE_MASTERFILES_DIR="$OPTARG"
@@ -51,14 +48,15 @@ do
 done
 
 ##
+CFENGINE_MODULES_DIR=$CFENGINE_MASTERFILES_DIR/modules
 CFENGINE_SERVICES_DIR=$CFENGINE_MASTERFILES_DIR/services
+CFENGINE_TEMPLATES_DIR=$CFENGINE_MASTERFILES_DIR/scl/.git/templates
 
 echo "MPF installation settings":
 cat << EOF
     dir: $CFENGINE_DIR
     masterfiles: $CFENGINE_MASTERFILES_DIR
     templates: $CFENGINE_TEMPLATES_DIR
-    modules: $CFENGINE_MODULES_DIR
 EOF
 
 if [ ! -d $CFENGINE_MASTERFILES_DIR ]
@@ -76,7 +74,6 @@ else
     echo "Installing SCL library and autorun file"
     cp --no-dereference -R $SCL_LIB $CFENGINE_MASTERFILES_DIR/lib/
 fi
-
 ### This is always updated
 #
 cp $SCL_AUTORUN_SERVICE $CFENGINE_SERVICES_DIR/autorun
@@ -104,24 +101,28 @@ cp -a $SCL_MODULES/* $CFENGINE_MODULES_DIR/scl
 #
 if [ ! -d  $CFENGINE_TEMPLATES_DIR ]
 then
-    mkdir $CFENGINE_TEMPLATES_DIR
+    mkdir --parents $CFENGINE_TEMPLATES_DIR
 fi
 
+echo "Installing  mustache template(s) and json file(s): $CFENGINE_TEMPLATES_DIR"
+cp --no-dereference -R $SCL_TEMPLATES $CFENGINE_TEMPLATES_DIR
+
+### old code
 ### Must we update templates/json files
-cd  $SCL_TEMPLATES || exit 1
-for d in *
-do
-        if [ -d $CFENGINE_TEMPLATES_DIR/$d ]
-        then
-            echo "Updating mustache template(s) and default.json: $d"
-            templates=$(ls $d/*.mustache 2>/dev/null)
-            if [ ! -z "$templates" ]
-            then
-                cp $d/*.mustache $CFENGINE_TEMPLATES_DIR/$d
-            fi
-            cp $d/json/default.json $CFENGINE_TEMPLATES_DIR/$d/json
-        else
-            echo "Installing  mustache template(s) and json file(s): $d"
-            cp --no-dereference -R $d $CFENGINE_TEMPLATES_DIR
-        fi
-done
+#cd  $SCL_TEMPLATES || exit 1
+#for d in *
+#do
+        #if [ -d $CFENGINE_TEMPLATES_DIR/$d ]
+        #then
+            #echo "Updating mustache template(s) and default.json: $d"
+            ##templates=$(ls $d/*.mustache 2>/dev/null)
+            #if [ ! -z "$templates" ]
+            #then
+                #cp $d/*.mustache $CFENGINE_TEMPLATES_DIR/$d
+            #fi
+            #cp $d/json/default.json $CFENGINE_TEMPLATES_DIR/$d/json
+        #else
+            #echo "Installing  mustache template(s) and json file(s): $d"
+            #cp --no-dereference -R $d $CFENGINE_TEMPLATES_DIR
+        #fi
+#done

--- a/scl_example.json
+++ b/scl_example.json
@@ -1,0 +1,15 @@
+{
+    "vars": {
+            "scl_inventory_modules": [
+                "scl/dmidecode"
+            ],
+            "scl_services_enabled": [
+                "ntp"
+            ],
+            "ntp": {
+                "server": [
+                    "example.ntp.org"
+                ]
+            }
+    }
+}


### PR DESCRIPTION
cfbs and mpf_installation use the same installationm for the
scl/templates and scl/modules. They are all placed in the masterfiles
directory.

The templates in lb/scl/.git/templates so that they are not copied
to the clients  with bootstrap/update run.